### PR TITLE
Fix bootstrap on OSX

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,7 +1,8 @@
 rm -rf config.cache autom4te*.cache
 #autoreconf --install
 
-libtoolize --automake
+case `uname` in Darwin*) glibtoolize --automake ;;
+  *) libtoolize --automake ;; esac
 aclocal
 autoconf
 autoheader


### PR DESCRIPTION
I'm not sure this is valid for all OSX installations (Homebrew?) but MacPorts names libtoolize "glibtoolize". http://stackoverflow.com/questions/15448582/installed-libtool-but-libtoolize-not-found
