### PR TITLE
initialize value of currently tunned freqency at start

### DIFF
--- a/src/usrp_source.cc
+++ b/src/usrp_source.cc
@@ -50,6 +50,7 @@ usrp_source::usrp_source(float sample_rate, long int fpga_master_clock_freq) {
 
 	m_fpga_master_clock_freq = fpga_master_clock_freq;
 	m_desired_sample_rate = sample_rate;
+	m_center_freq = 0.0;
 	m_sample_rate = 0.0;
 	m_decimation = 0;
 	m_cb = new circular_buffer(CB_LEN, sizeof(complex), 0);
@@ -61,6 +62,7 @@ usrp_source::usrp_source(float sample_rate, long int fpga_master_clock_freq) {
 usrp_source::usrp_source(unsigned int decimation, long int fpga_master_clock_freq) {
 
 	m_fpga_master_clock_freq = fpga_master_clock_freq;
+	m_center_freq = 0.0;
 	m_sample_rate = 0.0;
 	m_cb = new circular_buffer(CB_LEN, sizeof(complex), 0);
 


### PR DESCRIPTION
Although there is pretty low probability this can cause trouble, I will sleep better when the output will be deterministic under all circumstances ....
