### PR TITLE
Add an option to manually tune to an offset from the standard channel frequency

### DIFF
--- a/src/offset.cc
+++ b/src/offset.cc
@@ -40,7 +40,7 @@ static const float		OFFSET_MAX	= 40e3;
 extern int g_verbosity;
 
 
-int offset_detect(usrp_source *u) {
+int offset_detect(usrp_source *u, int hz_adjust) {
 
 #define GSM_RATE (1625000.0 / 6.0)
 
@@ -122,7 +122,7 @@ int offset_detect(usrp_source *u) {
 	printf("overruns: %u\n", overruns);
 	printf("not found: %u\n", notfound);
 
-	total_ppm = u->m_freq_corr - (avg_offset / u->m_center_freq) * 1000000;
+	total_ppm = u->m_freq_corr - ((avg_offset + hz_adjust) / u->m_center_freq) * 1000000;
 
 	printf("average absolute error: %.3f ppm\n", total_ppm);
 	return 0;

--- a/src/offset.h
+++ b/src/offset.h
@@ -25,4 +25,4 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-int offset_detect(usrp_source *u);
+int offset_detect(usrp_source *u, int hz_adjust);


### PR DESCRIPTION
This adds -E to allow manually feeding a tuning offset into a calibration run.

I found this useful for looking at tuner precision issues - run with varying tuning offsets and see how the measured signal offset changes. It's a bit simpler than trying to do the same thing by varying the PPM value.
