### PR TITLE
Added instalation instruction to the README.

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,19 @@ Kalibrate, or kal, can scan for GSM base stations in a given frequency band and
 can use those GSM base stations to calculate the local oscillator frequency
 offset.
 
+
+How to install:
+
+git clone https://github.com/steve-m/kalibrate-rtl
+cd kalibrate-rtl
+./bootstrap && CXXFLAGS='-W -Wall -O3'
+./configure
+make
+sudo make install
+
+
 See http://thre.at/kalibrate 
+
 
 Copyright (c) 2010, Joshua Lackey (jl@thre.at)
 


### PR DESCRIPTION
I had a difficult time figuring out how to install kalibrate-rtl because I expected the instructions to be in the README. I later found them in the wiki and thought they should be added.