### PR TITLE
Fix OpenBSD breakage from recent commits

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,12 +43,12 @@ case "$host_os" in
 		LRT_FLAGS=""
 		AC_SUBST(LRT_FLAGS)
 		;;
+	openbsd*)
+		AC_DEFINE([D_HOST_OPENBSD], [], [building for OpenBSD])
+		;;
 	*)
 		LRT_FLAGS="-lrt"
 		AC_SUBST(LRT_FLAGS)
-		;;
-	openbsd*)
-		AC_DEFINE([D_HOST_OPENBSD], [], [building for OpenBSD])
 		;;
 esac
 


### PR DESCRIPTION
A recent commit borked one of the changes I made last week.

It looks like  this happened automatically when someone merged from another branch. The fix was to put the wildcard after all the specific cases, where it's supposed to be.