### PR TITLE
added some packages required for building

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ kal uses the GNU Autoconf system and should be easily built on most \*nix platfo
 
 Debian example:
 ```
-$ sudo apt-get install libtool libfftw3-dev m4 librtlsdr-dev automake git
+$ sudo apt-get install libtool libfftw3-dev m4 librtlsdr-dev automake pkg-config git
 $ git clone https://github.com/steve-m/kalibrate-rtl.git
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ kal uses the GNU Autoconf system and should be easily built on most \*nix platfo
 Debian example:
 ```
 $ git clone https://github.com/steve-m/kalibrate-rtl.git
-$ sudo apt-get install libtool libfftw3-dev
+$ sudo apt-get install libtool libfftw3-dev m4 librtlsdr-dev automake
 ```
 
 ```

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ kal uses the GNU Autoconf system and should be easily built on most \*nix platfo
 
 Debian example:
 ```
+$ sudo apt-get install libtool libfftw3-dev m4 librtlsdr-dev automake git
 $ git clone https://github.com/steve-m/kalibrate-rtl.git
-$ sudo apt-get install libtool libfftw3-dev m4 librtlsdr-dev automake
 ```
 
 ```


### PR DESCRIPTION
some of the packages required for building this software, mostly `m4`, `librtlsdr-dev` and `automake` aren't being installed by default if apt has previously been [configured not to install suggested and recommended packages](https://superuser.com/questions/615565/can-i-make-apt-get-always-use-no-install-recommends) as is the case on minimalistic debian installations for example.